### PR TITLE
Fix loop variable usage in pathfinding

### DIFF
--- a/trunk/mpl_potentialfieldenvironment.cpp
+++ b/trunk/mpl_potentialfieldenvironment.cpp
@@ -222,7 +222,7 @@ int MPL_PotentialFieldEnvironment::getPath(MPL_Position &pos_start, MPL_Position
                                     (int)(y + d_vy),\
                                     (int)(z + d_vz));
 
-                for(i_aux = i-1; (i>=0) && (!b_reachedMinima); i--)
+                for(i_aux = i-1; (i_aux >= 0) && (!b_reachedMinima); i_aux--)
                 {
                     if( MPL_Position::manhattanDist(pos_path[i], pos_path[i_aux]) < 0.5 )
                     {


### PR DESCRIPTION
## Summary
- fix loop variable misuse in `MPL_PotentialFieldEnvironment::getPath`

## Testing
- `g++ -fsyntax-only trunk/mpl_potentialfieldenvironment.cpp` *(fails: QVector: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684377106a4c8326a743981572fb6c7a