### PR TITLE
Fix comment typo in main launcher

### DIFF
--- a/trunk/mpl_opf_parallelsor_mainlaucher.h
+++ b/trunk/mpl_opf_parallelsor_mainlaucher.h
@@ -197,7 +197,7 @@ private:
     MPL_OPF_ParallelSor_RedBlack::MPL_OPF_ParallelSor_ExternalState state_red__;
 
     /**
-     * @brief d_residuered_
+     * @brief d_residue_red_
      * Residue shared with pPSOR_sor_red_
      */
     double d_residue_red_;


### PR DESCRIPTION
## Summary
- correct misspelled `d_residue_red_` reference in PSOR main launcher header

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684378b8a5c08326939101ce95ef49e9